### PR TITLE
Fix NextAuth 401 error by skipping tenant context for auth routes

### DIFF
--- a/src/app/middleware.ts
+++ b/src/app/middleware.ts
@@ -11,9 +11,20 @@ export async function middleware(req: NextServer.NextRequest) {
   if (String(process.env.AUTH_DISABLED || '').toLowerCase() === 'true') {
     return NextServer.NextResponse.next()
   }
+  const { pathname } = req.nextUrl
+
+  if (
+    pathname.startsWith('/api/auth') ||
+    pathname.startsWith('/auth') ||
+    pathname.startsWith('/_next') ||
+    pathname.startsWith('/static') ||
+    pathname === '/favicon.ico'
+  ) {
+    return NextServer.NextResponse.next()
+  }
+
   const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
   const isAuth = !!token
-  const { pathname } = req.nextUrl
   const method = req.method
   const start = Date.now()
   const isApiRequest = pathname === '/api' || pathname.startsWith('/api/')

--- a/src/lib/prisma-tenant-guard.ts
+++ b/src/lib/prisma-tenant-guard.ts
@@ -27,6 +27,7 @@ const WRITE_ACTIONS: ReadonlySet<GuardedAction> = new Set(['create', 'createMany
 const BULK_MUTATION_ACTIONS: ReadonlySet<GuardedAction> = new Set(['updateMany', 'deleteMany'])
 const SINGLE_MUTATION_ACTIONS: ReadonlySet<GuardedAction> = new Set(['update', 'delete'])
 const READ_ACTIONS: ReadonlySet<GuardedAction> = new Set(['findFirst', 'findUnique', 'findMany', 'aggregate', 'count', 'groupBy'])
+const AUTH_MODEL_NAMES: ReadonlySet<string> = new Set(['User', 'Account', 'Session', 'VerificationToken'])
 
 let tenantModelConfigs: ReadonlyMap<string, TenantModelConfig> | null = null
 

--- a/src/lib/prisma-tenant-guard.ts
+++ b/src/lib/prisma-tenant-guard.ts
@@ -192,6 +192,14 @@ export function enforceTenantGuard(params: any): void {
   const model = params.model
   if (!model) return
 
+  if (AUTH_MODEL_NAMES.has(model)) return
+
+  const requestUrl =
+    typeof params?.args?.context?.req?.url === 'string'
+      ? params.args.context.req.url
+      : null
+  if (requestUrl && requestUrl.includes('/api/auth')) return
+
   const config = tenantModelConfigs?.get(model)
   if (!config) return
 


### PR DESCRIPTION
## Purpose

Resolve the `401 Unauthorized` issue occurring during NextAuth login after implementing the tenant context system. The problem was that tenant context logic was being applied globally, including to NextAuth's internal routes, which must remain global (non-tenant) for authentication to succeed. NextAuth routes need access to the global `User` model for login verification and should not be wrapped by tenant-specific Prisma clients.

## Code Changes

### 1. Updated middleware.ts
- Added early return logic to skip tenant context for NextAuth and internal routes
- Routes bypassed include:
  - `/api/auth/*` - NextAuth API endpoints
  - `/auth/*` - Auth pages
  - `/_next/*` - Next.js internal paths
  - `/static/*` - Static assets
  - `/favicon.ico` - Favicon requests
- Moved `pathname` extraction earlier in the function for reuse

### 2. Enhanced prisma-tenant-guard.ts
- Added `AUTH_MODEL_NAMES` constant to identify NextAuth models (`User`, `Account`, `Session`, `VerificationToken`)
- Added guard to skip tenant enforcement for auth-related models
- Added additional check to bypass tenant guard when request URL contains `/api/auth`
- These changes ensure NextAuth operations can access global models without tenant restrictions

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 462`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8504cee40e3846d2b855bf664675c4ad/curry-space)

👀 [Preview Link](https://8504cee40e3846d2b855bf664675c4ad-curry-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8504cee40e3846d2b855bf664675c4ad</projectId>-->
<!--<branchName>curry-space</branchName>-->